### PR TITLE
Update Convert_GeoIPDB_To_Netscaler_Format_WithContinent.pl

### DIFF
--- a/Convert_GeoIPDB_To_Netscaler_Format_WithContinent.pl
+++ b/Convert_GeoIPDB_To_Netscaler_Format_WithContinent.pl
@@ -634,7 +634,7 @@ fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|
 			}
 			print LOG $logmsg;
 			 #print OUT "$start_ip,$end_ip,,$out_county_code,$out_sub_dv,$out_city,,,$longitude,$latitude\n";
-			print OUT "$start_ip,$end_ip,$out_county_code,$out_sub_dv_1,$out_sub_dv_2,$out_city,,$longitude,$latitude\n";
+			print OUT "$start_ip,$end_ip,,$out_county_code,$out_sub_dv_1,$out_sub_dv_2,$out_city,,$longitude,$latitude\n";
 		}
 		else{
 			if(!defined $start_invalid_addr){


### PR DESCRIPTION
Original author perhaps didn't validate by importing converted Netscaler_Maxmind_GeoIP_DB_IPv6.csv to netscaler.

It was missing a comma in output file Netscaler_Maxmind_GeoIP_DB_IPv6.csv  generated by script.

I learn about this formatting mistake by comparing Netscaler_Maxmind_GeoIP_DB_IPv6 with one that comes from Citrix.

So, I have added missing coma at line#637 which was responsible for broken Netscaler_Maxmind_GeoIP_DB_IPv6.csv in output file.